### PR TITLE
Fix LICENSE description in READMEs

### DIFF
--- a/README.ch.md
+++ b/README.ch.md
@@ -56,4 +56,8 @@ jupyter serverextension enable <output source directory>
 * 如果你想关掉TabNine自动补全，既可以在Notebook nbextension 的页面 disable Jupyter TabNine。也可以点击 `Help` 在弹框中找到 Jupyter TabNine把它点掉。
 * 远程补全服务器也是支持的。如果你想部署个Server来处理客户端插件请求，或者你们公司在`Kubernetes`上部署一个Server Cluter请看下面章节了解如何部署自动补全Server。
 
+## 开源许可证
+
+[MIT License](LICENSE)
+
 ## 部署自动补全Server (可选)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 Please make sure to update tests as appropriate.
 
 ## License
-[GNU General Public License v3.0](LICENSE)
+[MIT License](LICENSE)
 
 ## Remote Completion Server Deployment


### PR DESCRIPTION
Given the LICENSE file in the code base, I suspect the actual code license being MIT.

Therefore, I made two fixes on README.md and README.ch.md with updated description on license links.